### PR TITLE
Use frame count for time handling

### DIFF
--- a/common.h
+++ b/common.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 typedef struct BoundingBox_s {
     int x1;
     int x2;
@@ -5,10 +7,18 @@ typedef struct BoundingBox_s {
     int y2;
 } BoundingBox_t;
 
+typedef struct frate_s {
+    char *name;
+    int rate;
+    double frame_dur;
+    uint64_t num;
+    uint64_t denom;
+} frate_t;
+
 typedef struct image_s {
     int width, height, stride, dvd_mode;
     int subx1, suby1, subx2, suby2;
-    long long in, out;
+    uint64_t in, out;
     BoundingBox_t crops[2];
     uint8_t *buffer;
 } image_t;
@@ -20,7 +30,6 @@ typedef struct eventlist_s {
 
 typedef struct opts_s {
     double par;
-    int fps;
     int frame_w;
     int frame_h;
     int render_w;
@@ -33,4 +42,4 @@ typedef struct opts_s {
     const char *fontdir;
 } opts_t;
 
-eventlist_t *render_subs(char *subfile, int frame_d, opts_t *args);
+eventlist_t *render_subs(char *subfile, frate_t *frate, opts_t *args);

--- a/render.c
+++ b/render.c
@@ -457,12 +457,17 @@ eventlist_t *render_subs(char *subfile, frate_t *frate, opts_t *args)
                 break;
             case 0:
             {
-                tm = frame_to_realtime_ms(frame_cnt, frate, SAMPLE_TC_MID);    
-                uint64_t offset = ass_step_sub(track, tm, 1);
-                ++frame_cnt;
+                tm = (uint64_t)ass_step_sub(track, frame_to_realtime_ms(frame_cnt, frate, SAMPLE_TC_MID), 1);
+                uint64_t offset = (tm*frate->rate)/1000;
 
-                if (tm && !offset)
+                if (!tm && frame_cnt > 1)
                     goto finish;
+
+                if (offset == 0) {
+                    offset = 1; //avoid deadlocks
+                }
+
+                frame_cnt += offset;
                 break;
             }
         }

--- a/render.c
+++ b/render.c
@@ -10,6 +10,13 @@
 #define MIN(a,b) ((a) > (b) ? (b) : (a))
 #define BOX_AREA(box) ((box.x2-box.x1)*(box.y2-box.y1))
 
+typedef enum SamplingFlag_s {
+    SAMPLE_TC_IN  = 0,
+    SAMPLE_TC_OUT,
+    SAMPLE_TC_MID,
+    INVALID_SAMPLING
+} SamplingFlag_t;
+
 ASS_Library *ass_library;
 ASS_Renderer *ass_renderer;
 
@@ -357,34 +364,51 @@ static int find_split(image_t *frame)
     return best_score < (uint32_t)(-1);
 }
 
-static int get_frame(ASS_Renderer *renderer, ASS_Track *track, image_t *frame,
-                     long long time, int frame_d)
+static uint64_t frame_to_realtime_ms(uint64_t frame_cnt, frate_t *frate, SamplingFlag_t flag)
+{
+    if (flag == SAMPLE_TC_OUT) {
+        return (uint64_t)floor((1000 * frame_cnt * frate->denom)/(double)frate->num);
+    } else if (flag == SAMPLE_TC_IN) {
+        return (uint64_t)ceil((1000*(frame_cnt - 1) * frate->denom)/(double)frate->num);
+    } else if (flag == SAMPLE_TC_MID) {
+        return (uint64_t)round(((1000*frame_cnt * frate->denom)/frate->num) - (500*frate->denom)/frate->num);
+    }
+    fprintf(stderr, "Invalid sampling flag.\n");
+    exit(1);
+}
+
+static int get_frame(ASS_Renderer *renderer, ASS_Track *track,
+                     image_t *frame, uint64_t frame_cnt, frate_t *frate)
 {
     int changed;
-    ASS_Image *img = ass_render_frame(renderer, track, time, &changed);
+
+    uint64_t ms = frame_to_realtime_ms(frame_cnt, frate, SAMPLE_TC_MID);
+    ASS_Image *img = ass_render_frame(renderer, track, ms, &changed);
 
     if (changed && img) {
-        frame->out = time + frame_d;
+        frame->out = frame_cnt + 1;
         blend(frame, img);
-        frame->in = time;
+        frame->in = frame_cnt;
 
         if (frame->subx1 == -1 || frame->suby1 == -1)
             return 2;
 
         return 3;
     } else if (!changed && img) {
-        frame->out = time + frame_d;
+        ++frame->out;
         return 1;
     } else {
         return 0;
     }
 }
 
-eventlist_t *render_subs(char *subfile, int frame_d, opts_t *args)
+eventlist_t *render_subs(char *subfile, frate_t *frate, opts_t *args)
 {
     long long tm = 0;
     int count = 0, fres = 0;
     int img_cnt;
+
+    uint64_t frame_cnt = 1;
 
     eventlist_t *evlist = calloc(1, sizeof(eventlist_t));
 
@@ -403,7 +427,7 @@ eventlist_t *render_subs(char *subfile, int frame_d, opts_t *args)
             eventlist_set(evlist, frame, count - 1);
         }
 
-        fres = get_frame(ass_renderer, track, frame, tm, frame_d);
+        fres = get_frame(ass_renderer, track, frame, frame_cnt, frate);
 
         switch (fres) {
             case 3:
@@ -429,16 +453,16 @@ eventlist_t *render_subs(char *subfile, int frame_d, opts_t *args)
             /* fall through */
             case 2:
             case 1:
-                tm += frame_d;
+                ++frame_cnt;
                 break;
             case 0:
             {
-                long long offset = ass_step_sub(track, tm, 1);
+                tm = frame_to_realtime_ms(frame_cnt, frate, SAMPLE_TC_MID);    
+                uint64_t offset = ass_step_sub(track, tm, 1);
+                ++frame_cnt;
 
                 if (tm && !offset)
                     goto finish;
-
-                tm += offset;
                 break;
             }
         }


### PR DESCRIPTION
The BDNXML format uses SMPTE timecode while Advanced Sub Station files uses timestamps. The motivation for this MR is to use the output time unit and sample the ASS file in the middle of the frame and fix the current behaviour. The implementation in main makes rough approximations that lead to localized event drift by one or two frame. 

Mathematically, this MR implements sampling at $t_{s_i} = t_{f_i} + (2fps)^{-1}$, where $t_{f_i}$ denotes the timestamp when frame $i$ appears. As a result, frame-by-frame effects like masking are more likely to be in sync.
This also fixes the rare occurences of zero-duration events.