### PR TITLE
Add image quantization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,10 @@
 Convert ASS subtitles into BDN XML + PNG images
 ===============================================
 
-ass2bdnxml is a command line software originally written by `mia0 <https://github.com/mia-0>`_  to convert .ASS to BDN XML + PNG assets.
-The generated files can then be imported in Blu-Ray authoring softwares or used in `SUPer <https://github.com/cubicibo/SUPer>`_ to generate raw PGS stream files, usable in software like tsMuxer.
-This fork enables additional options revolving around libass to support more complex ASS files. It also fixes alpha blending and features optional event splitting across two graphics to reduce buffer usage when the BDNXML is directly imported in the authoring software.
+ass2bdnxml is a command line software originally written by `mia-0 <https://github.com/mia-0>`_  to convert .ASS to BDN XML + PNG assets.
+
+The generated files can then be imported in Blu-Ray authoring softwares or used in `SUPer <https://github.com/cubicibo/SUPer>`_ to generate Presentation Graphic Streams (PGS) files, usable in software like tsMuxer.
+This fork enables advanced libass features like embedded fonts. It fixes alpha blending, improves time handling, adds event splitting across two graphics and image quantization via libimagequant.
 
 Building
 --------
@@ -15,66 +16,82 @@ You can either use Meson (see `the Meson documentation <https://mesonbuild.com/>
 
 Or you can build it without using a build system::
 
-    cc *.c -o ass2bdnxml $(pkg-config --cflags --libs libass) $(pkg-config --cflags --libs png) -lm
+    cc *.c -o ass2bdnxml $(pkg-config --cflags --libs libass) $(pkg-config --cflags --libs libpng) $(pkg-config --cflags --libs imagequant) -lm
 
-(Depending on your platform, you may have to omit ``-lm`` and replace ``png`` by ``libpng``)
+(Depending on your platform, you may have to omit ``-lm`` and replace ``libpng`` by ``png``)
 
 Usage
 -----
 
-``ass2bdnxml`` will write its output to the current working directory.
+``ass2bdnxml`` will write the output bdn.xml and PNGs to the current working directory.
 Simply invoke it like this::
 
-    ass2bdnxml ../subtitles.ass
+    ass2bdnxml [OPTIONS] PATH_TO_FILE/subs.ass
 
 The following optional arguments are available:
 
 +--------------------+--------------------------------------------------------+
 | Option             | Effect                                                 |
 +====================+========================================================+
+| ``-v``             | Sets the video format to render subtitles in.          |
+| ``--video-format`` | Choices: 1080p, 1080i, 720p, 576i, 480p, 480i          |
+|                    | Default: ``1080p``                                     |
++--------------------+--------------------------------------------------------+
+| ``-f``             | Sets the video frame rate.                             |
+| ``--fps``          | Choices: 23.976, 24, 25, 29.97, 50, 59.94              |
+|                    | Default: ``23.976``                                    |
++--------------------+--------------------------------------------------------+
+| ``-q``             | Sets and enable image quantization with N colors.      |
+| ``--quantize``     | Choices: value in [0; 255]                             |
+|                    | Default: ``0`` (Disabled, PNGs are 32-bit RGBA)        |
+|                    | Note: Do not use if the BDNXML is generated for SUPer. |
+|                    | This must be enabled if target software is Scenarist BD|
++--------------------+--------------------------------------------------------+
+| ``-a``             | Sets an additional font directory for custom fonts not |
+| ``--fontdir``      | embedded in the ASS or provided by the OS font manager.|
++--------------------+--------------------------------------------------------+
+| ``-s``             | Sets the event split across 2 graphics behaviour.      |
+| ``--split``        | 0: Disabled, 1: Normal, 2: Aggressive. Default: ``0``  |
+|                    | Note: Do not use if the BDNXML is generated for SUPer. |
++--------------------+--------------------------------------------------------+
+| ``-p``             | Sets the ASS pixel aspect ratio. Required for          |
+| ``--par``          | anamorphic content. Defaults to libass default value.  |
++--------------------+--------------------------------------------------------+
+| ``-o``             | Sets the TC offset to shift all of the BDN Timecodes.  |
+| ``--offset``       | Default: ``00:00:00:00`` (offset of zero frame)        |
+|                    | Note: TC string must be the standard SMPTE NDF format. |
++--------------------+--------------------------------------------------------+
+| ``-z``             | Flag to indicate a negative ``--offset``.              |
+| ``--negative``     | Ignored if no offset is provided.                      |
++--------------------+--------------------------------------------------------+
+| ``-r``             | Flag to encode PNGs without using palette entry zero   |
+| ``--rleopt``       | Can maybe prevent RLE/line width errors in Scenarist.  |
+|                    | Ignored if ``--quantize`` is not used.                 |
++--------------------+--------------------------------------------------------+
 | ``-t``             | Sets the human-readable name of the subtitle track.    |
 | ``--trackname``    | Default: ``Undefined``                                 |
 +--------------------+--------------------------------------------------------+
 | ``-l``             | Sets the language of the subtitle track.               |
 | ``--language``     | Default: ``und``                                       |
 +--------------------+--------------------------------------------------------+
-| ``-v``             | Sets the video format to render subtitles in.          |
-| ``--video-format`` | Choices: 1080p, 1080i, 720p, 576i, 480p, 480i          |
-|                    | Default: 1080p                                         |
-+--------------------+--------------------------------------------------------+
-| ``-f``             | Sets the video frame rate.                             |
-| ``--fps``          | Choices: 23.976, 24, 25, 29.97, 50, 59.94              |
-|                    | Default: 23.976                                        |
-+--------------------+--------------------------------------------------------+
-| ``-d``             | Applies a contrast change that hopefully improves      |
+| ``-d``             | Flag to apply a contrast change that hopefully improves|
 | ``--dvd-mode``     | subtitle appearance with the limited resolution and    |
 |                    | color palette of DVD subtitles.                        |
 +--------------------+--------------------------------------------------------+
-| ``-w``             | Specify the .ass width to use as frame & storage space |
-| ``--render-width`` | The output width is used if not specified. Some ass    |
+| ``-w``             | Sets the width to use as ASS frame & storage space     |
+| ``--render-width`` | Defaults to output width if not specified. Some ass    |
 |                    | tags may not render properly if the value is improper. |
 +--------------------+--------------------------------------------------------+
-| ``-h``             | Specify the .ass height to use as frame space          |
-| ``--render-height``| The output height is used if not specified. Some ass   |
+| ``-h``             | Sets the height to use as ASS frame & storage space    |
+| ``--render-height``| Defaults to output height if not specified. Some ass   |
 |                    | tags may not render properly if the value is improper. |
 +--------------------+--------------------------------------------------------+
-| ``-g``             | libass hinting will be enabled if provided.            |
+| ``-g``             | Flag to enable libass hinting.                         |
 | ``--hinting``      |                                                        |
 +--------------------+--------------------------------------------------------+
-| ``-p``             | Set the pixel aspect ratio in libass. Required for     |
-| ``--par``          | anamorphic content. Defaults to libass default value.  |
+| ``-x``             | Sets the ASS storage width. I.e the pre-anamorphic     |
+| ``--width-store``  | width. ``-p`` should be preferred, Last resort option. |
 +--------------------+--------------------------------------------------------+
-| ``-x``             | ASS storage width to use in libass. Typically the      |
-| ``--width-store``  | before-anamorphic width. -p should be preferred, over  |
-|                    | setting the storage space. Last resort option generally|
-+--------------------+--------------------------------------------------------+
-| ``-y``             | ASS storage height to use in libass. Should be left    |
-| ``--height-store`` | as default unless the video format is non-standard.    |
-+--------------------+--------------------------------------------------------+
-| ``-a``             | Specify an additional font directory for custom fonts  |
-| ``--fontdir``      | not in the OS font manager or embedded in the ASS.     |
-+--------------------+--------------------------------------------------------+
-| ``-s``             | Whenever possible, split an event in two graphic       |
-| ``--split``        | objects. This may reduce the buffer usage.             |
-|                    | Should NOT be used if the BDNXML is generated for SUPer|
+| ``-y``             | Sets the ASS storage height. Last resort option for    |
+| ``--height-store`` | ASS with complex transforms with unusual video height. |
 +--------------------+--------------------------------------------------------+

--- a/ass2bdnxml.c
+++ b/ass2bdnxml.c
@@ -178,9 +178,10 @@ int main(int argc, char *argv[])
     frate_t *frate = NULL;
     vfmt_t *vfmt = NULL;
     eventlist_t *evlist;
+
+    uint8_t negative_offset = 0;
     uint8_t offset_vals[4];
     memset(offset_vals, 0, sizeof(offset_vals));
-    uint8_t negative_offset = 0;
 
     opts_t args;
     memset(&args, 0, sizeof(args));
@@ -205,13 +206,13 @@ int main(int argc, char *argv[])
         {"par",          required_argument, 0, 'p'},
         {"fontdir",      required_argument, 0, 'a'},
         {"offset",       required_argument, 0, 'o'},
+        {"quantize",     required_argument, 0, 'q'},
         {0, 0, 0, 0}
     };
-    const char **err = NULL;
 
     while (1) {
         int opt_index = 0;
-        int c = getopt_long(argc, argv, "zsdgt:l:v:f:w:h:x:y:p:a:o:", longopts, &opt_index);
+        int c = getopt_long(argc, argv, "zsdgt:l:v:f:w:h:x:y:p:a:o:q:", longopts, &opt_index);
 
         if (c == -1)
             break;
@@ -249,33 +250,36 @@ int main(int argc, char *argv[])
                 break;
             case 'w':
                 args.render_w = (int)strtol(optarg, NULL, 10);
-                //args.render_w = (int)strtonum(optarg, 0, 4096, err);
-                if (err != NULL || args.render_w <= 0 || args.render_w > 4096) {
-                    printf("Invalid render width.");
+                if (args.render_w <= 0 || args.render_w > 4096) {
+                    printf("Invalid render width.\n");
                     exit(1);
                 }
                 break;
             case 'h':
                 args.render_h = (int)strtol(optarg, NULL, 10);
-                //args.render_h = (int)strtonum(optarg, 0, 4096, err);
-                if (err != NULL || args.render_h <= 0 || args.render_h > 4096) {
-                    printf("Invalid render height.");
+                if (args.render_h <= 0 || args.render_h > 4096) {
+                    printf("Invalid render height.\n");
                     exit(1);
                 }
                 break;
             case 'x':
                 args.storage_w = (int)strtol(optarg, NULL, 10);
-                //args.storage_w = (int)strtonum(optarg, 0, 4096, err);
-                if (err != NULL || args.storage_w <= 0 || args.storage_w  > 4096) {
-                    printf("Invalid storage width.");
+                if (args.storage_w <= 0 || args.storage_w  > 4096) {
+                    printf("Invalid storage width.\n");
                     exit(1);
                 }
                 break;
             case 'y':
                 args.storage_h = (int)strtol(optarg, NULL, 10);
-                //args.storage_h = (int)strtonum(optarg, 0, 4096, err);
-                if (err != NULL || args.storage_h <= 0 || args.storage_h > 4096) {
-                    printf("Invalid storage height.");
+                if (args.storage_h <= 0 || args.storage_h > 4096) {
+                    printf("Invalid storage height.\n");
+                    exit(1);
+                }
+                break;
+            case 'q':
+                args.quantize = (uint16_t)strtol(optarg, NULL, 10);
+                if (args.quantize == 0 || args.quantize > 255) {
+                    printf("Colours must be within [0; 255] (0 = no quantization).\n");
                     exit(1);
                 }
                 break;
@@ -333,7 +337,7 @@ int main(int argc, char *argv[])
     if (args.render_h == 0)
         args.render_h = args.frame_h;
     if (args.render_h > args.frame_h || args.render_w > args.frame_w) {
-        printf("Cannot render an ASS that has larger width or height than target.\n");
+        printf("Cannot render ASS file with larger width or height than video format.\n");
         exit(1);
     }
     if (args.storage_h > 0 || args.storage_w > 0) {

--- a/ass2bdnxml.c
+++ b/ass2bdnxml.c
@@ -290,8 +290,8 @@ int main(int argc, char *argv[])
                 break;
             case 'q':
                 args.quantize = (uint16_t)strtol(optarg, NULL, 10);
-                if (args.quantize == 0 || args.quantize > 255) {
-                    printf("Colours must be within [0; 255] (0 = no quantization).\n");
+                if (args.quantize > 255) {
+                    printf("Colours must be within [0; 255] (default: 0, no quantization, 32-bit RGBA PNGs).\n");
                     exit(1);
                 }
                 break;

--- a/ass2bdnxml.c
+++ b/ass2bdnxml.c
@@ -14,6 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+/* Additional changes: Copyright © 2023, cubicibo
+ * The same agreement notice applies.
+ */
+
 #include <getopt.h>
 #include <math.h>
 #include <stdio.h>

--- a/common.h
+++ b/common.h
@@ -41,6 +41,7 @@ typedef struct opts_s {
     uint8_t dvd_mode;
     uint8_t hinting;
     uint8_t split;
+    uint8_t rle_optimise;
     const char *fontdir;
 } opts_t;
 

--- a/common.h
+++ b/common.h
@@ -37,9 +37,10 @@ typedef struct opts_s {
     int render_h;
     int storage_w;
     int storage_h;
-    int dvd_mode;
-    int hinting;
-    int split;
+    uint16_t quantize;
+    uint8_t dvd_mode;
+    uint8_t hinting;
+    uint8_t split;
     const char *fontdir;
 } opts_t;
 

--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ src = ['ass2bdnxml.c', 'render.c']
 deps = [
     dependency('libass', required: true),
     dependency('libpng', required: true),
+    dependency('imagequant', required: true),
     meson.get_compiler('c').find_library('m', required: false)
 ]
 


### PR DESCRIPTION
- Add libimagequant to output quantized images with 8-bit palettes. `--quantize N`, with N number of colours, enables image quantization. Else, 32-bit RGBA remains the default output format.
- Change `--split` to be a parameter with value. Possible values are: 0: disabled (default), 1: normal, 2: aggressive.
- Add `--rleopt` flag to prevent the usage of palette entry 0 for the most common colour. To encode a single pixel of color C, RLE for C=0 requires two bytes, while it is only one for C>0. If the image alternates between C=0 and C>0 pixels (due to dithering or a gradient), `RLE_Line_Width > bitmap_width + 16` will be true, which is strictly illegal according to BD specs.