### PR TITLE
Optimise palette generation for PGS.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,18 +77,11 @@ The following optional arguments are available:
 | ``-c``             | Flag to name the output XML according to the input ASS |
 | ``--copyname``     | file. The input ASS file must have a valid extension.  |
 +--------------------+--------------------------------------------------------+
-| ``-n``             | Merge together events that are reported as different   |
-| ``--no-dupes``     | by libass yet identical when composited (e.g ASSDraw). |
-+--------------------+--------------------------------------------------------+
 | ``-t``             | Sets the human-readable name of the subtitle track.    |
 | ``--trackname``    | Default: ``Undefined``                                 |
 +--------------------+--------------------------------------------------------+
 | ``-l``             | Sets the language of the subtitle track.               |
 | ``--language``     | Default: ``und``                                       |
-+--------------------+--------------------------------------------------------+
-| ``-d``             | Flag to apply a contrast change that may improve       |
-| ``--dvd-mode``     | subtitle appearance with the limited resolution and    |
-|                    | color palette of DVD subtitles.                        |
 +--------------------+--------------------------------------------------------+
 | ``-w``             | Sets the width to use as ASS frame & storage space     |
 | ``--render-width`` | Defaults to output width if not specified. Some ass    |
@@ -97,9 +90,6 @@ The following optional arguments are available:
 | ``-h``             | Sets the height to use as ASS frame & storage space    |
 | ``--render-height``| Defaults to output height if not specified. Some ass   |
 |                    | tags may not render properly if the value is improper. |
-+--------------------+--------------------------------------------------------+
-| ``-g``             | Flag to enable libass soft hinting.                    |
-| ``--hinting``      |                                                        |
 +--------------------+--------------------------------------------------------+
 | ``-x``             | Sets the ASS storage width. I.e the pre-anamorphic     |
 | ``--width-store``  | width. ``-p`` should be preferred, Last resort option. |
@@ -123,4 +113,19 @@ Below are parameters to tune libimagequant (LIQ). Those shall only be used along
 | ``--liq-dither``   | Dithering level, value must be within [0; 1.0] incl.   |
 |                    | Default: ``1.0``. Disable: ``0``. LIQ dithering is soft|
 |                    | so default or ``0.5`` is perfect in general.           |
++--------------------+--------------------------------------------------------+
+
+Moreover, the last table has debugging parameters. These should not have any practical in most scenarios.
+
++--------------------+--------------------------------------------------------+
+| Option             | Effect                                                 |
++====================+========================================================+
+| ``-d``             | Flag to apply a contrast change that may improve       |
+| ``--dvd-mode``     | subtitle appearance with the limited resolution and    |
+|                    | color palette of DVD subtitles.                        |
++--------------------+--------------------------------------------------------+
+| ``--keep-dupes``   | Flag to not merge events that are reported as different|
+|                    | by libass yet identical when composited (e.g ASSDraw). |
++--------------------+--------------------------------------------------------+
+| ``--hinting``      | Flag to enable soft hinting in libass.                 |
 +--------------------+--------------------------------------------------------+

--- a/ass2bdnxml.c
+++ b/ass2bdnxml.c
@@ -53,9 +53,12 @@ vfmt_t vfmts[] = {
     {NULL, 0, 0}
 };
 
-#define OPT_LIQ_SPEED   1000
-#define OPT_LIQ_DITHER  1001
-#define OPT_LIQ_MAXQUAL 1002
+#define OPT_ARG_HINTING   998
+#define OPT_ARG_KEEPDUPES 999
+
+#define OPT_LIQ_SPEED     1000
+#define OPT_LIQ_DITHER    1001
+#define OPT_LIQ_MAXQUAL   1002
 
 static void die_usage(const char *name)
 {
@@ -233,11 +236,9 @@ int main(int argc, char *argv[])
         {"copyname",     no_argument,       0, 'c'},
         {"dvd-mode",     no_argument,       0, 'd'},
         {"fps",          required_argument, 0, 'f'},
-        {"hinting",      no_argument,       0, 'g'},
         {"height-render",required_argument, 0, 'h'},
         {"language",     required_argument, 0, 'l'},
         {"splitmargin",  required_argument, 0, 'm'},
-        {"no-dupes",     no_argument,       0, 'n'},
         {"offset",       required_argument, 0, 'o'},
         {"par",          required_argument, 0, 'p'},
         {"quantize",     required_argument, 0, 'q'},
@@ -249,6 +250,8 @@ int main(int argc, char *argv[])
         {"width-store",  required_argument, 0, 'x'},
         {"height-store", required_argument, 0, 'y'},
         {"negative",     no_argument,       0, 'z'},
+        {"hinting",      no_argument,       0, OPT_ARG_HINTING},
+        {"keep-dupes",   no_argument,       0, OPT_ARG_KEEPDUPES},
         {"liq-dither",   required_argument, 0, OPT_LIQ_DITHER},
         {"liq-quality",  required_argument, 0, OPT_LIQ_MAXQUAL},
         {"liq-speed",    required_argument, 0, OPT_LIQ_SPEED},
@@ -257,7 +260,7 @@ int main(int argc, char *argv[])
 
     while (1) {
         int opt_index = 0;
-        int c = getopt_long(argc, argv, "czdgjrt:l:v:f:w:h:x:y:p:a:o:q:s:m:k:", longopts, &opt_index);
+        int c = getopt_long(argc, argv, "cdgrza:f:h:l:m:o:p:q:s:t:v:w:x:y:", longopts, &opt_index);
 
         if (c == -1)
             break;
@@ -278,7 +281,7 @@ int main(int argc, char *argv[])
             case 'r':
                 args.rle_optimise = 1;
                 break;
-            case 'g':
+            case OPT_ARG_HINTING:
                 args.hinting = 1;
                 break;
             case 't':
@@ -352,8 +355,8 @@ int main(int argc, char *argv[])
                     ++args.quantize;
                 }
                 break;
-            case 'n':
-                args.find_dupes = 1;
+            case OPT_ARG_KEEPDUPES:
+                args.keep_dupes = 1;
                 break;
             case OPT_LIQ_SPEED:
                 liqargs.speed = (uint8_t)strtol(optarg, NULL, 10);

--- a/ass2bdnxml.c
+++ b/ass2bdnxml.c
@@ -229,26 +229,26 @@ int main(int argc, char *argv[])
     }
 
     static struct option longopts[] = {
-        {"dvd-mode",     no_argument,       0, 'd'},
-        {"hinting",      no_argument,       0, 'g'},
-        {"negative",     no_argument,       0, 'z'},
-        {"rleopt",       no_argument,       0, 'r'},
+        {"fontdir",      required_argument, 0, 'a'},
         {"copyname",     no_argument,       0, 'c'},
-        {"no-dupes",     no_argument,       0, 'n'},
-        {"split",        required_argument, 0, 's'},
-        {"splitmargin",  required_argument, 0, 'm'},
-        {"trackname",    required_argument, 0, 't'},
-        {"language",     required_argument, 0, 'l'},
-        {"video-format", required_argument, 0, 'v'},
+        {"dvd-mode",     no_argument,       0, 'd'},
         {"fps",          required_argument, 0, 'f'},
-        {"width-render", required_argument, 0, 'w'},
+        {"hinting",      no_argument,       0, 'g'},
         {"height-render",required_argument, 0, 'h'},
+        {"language",     required_argument, 0, 'l'},
+        {"splitmargin",  required_argument, 0, 'm'},
+        {"no-dupes",     no_argument,       0, 'n'},
+        {"offset",       required_argument, 0, 'o'},
+        {"par",          required_argument, 0, 'p'},
+        {"quantize",     required_argument, 0, 'q'},
+        {"rleopt",       no_argument,       0, 'r'},
+        {"split",        required_argument, 0, 's'},
+        {"trackname",    required_argument, 0, 't'},
+        {"video-format", required_argument, 0, 'v'},
+        {"width-render", required_argument, 0, 'w'},
         {"width-store",  required_argument, 0, 'x'},
         {"height-store", required_argument, 0, 'y'},
-        {"par",          required_argument, 0, 'p'},
-        {"fontdir",      required_argument, 0, 'a'},
-        {"offset",       required_argument, 0, 'o'},
-        {"quantize",     required_argument, 0, 'q'},
+        {"negative",     no_argument,       0, 'z'},
         {"liq-dither",   required_argument, 0, OPT_LIQ_DITHER},
         {"liq-quality",  required_argument, 0, OPT_LIQ_MAXQUAL},
         {"liq-speed",    required_argument, 0, OPT_LIQ_SPEED},
@@ -344,11 +344,13 @@ int main(int argc, char *argv[])
                 break;
             case 'q':
                 args.quantize = (uint16_t)strtol(optarg, NULL, 10);
-                if (args.quantize > 255) {
-                    printf("Colours must be within [0; 255] incl. (default: 0, no quantization, output are 32-bit RGBA PNGs).\n");
+                if (args.quantize > 256) {
+                    printf("Colours must be within [0; 256] incl. (default: 0, no quantization, output 32-bit RGBA PNGs).\n");
                     exit(1);
+                } else if (1 == args.quantize) {
+                    //Cannot quantize with just a single color.
+                    ++args.quantize;
                 }
-                args.quantize += (args.quantize == 1);
                 break;
             case 'n':
                 args.find_dupes = 1;
@@ -383,9 +385,9 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (argc - optind == 1)
+    if (argc - optind == 1) {
         subfile = argv[optind];
-    else {
+    } else {
         printf("Only a single input file allowed.\n");
         exit(1);
     }
@@ -393,8 +395,7 @@ int main(int argc, char *argv[])
         int len = strlen(subfile);
         int ext_pos = -1;
 
-        for (i = len-1; i >= -1; --i)
-        {
+        for (i = len-1; i >= -1; --i) {
             if (i == -1 || subfile[i] == '\\'|| subfile[i] == '/') {
                 bdnfile = (char*)malloc(len - i + 1);
                 memcpy(bdnfile, &subfile[i+1], len - i);
@@ -415,11 +416,9 @@ int main(int argc, char *argv[])
 
     i = 0;
 
-    while (frates[i].name != NULL)
-    {
+    while (frates[i].name != NULL) {
         if (!strcasecmp(frates[i].name, frame_rate))
             frate = &frates[i];
-
         i++;
     }
 
@@ -430,11 +429,9 @@ int main(int argc, char *argv[])
 
     i = 0;
 
-    while (vfmts[i].name != NULL)
-    {
+    while (vfmts[i].name != NULL) {
         if (!strcasecmp(vfmts[i].name, video_format))
             vfmt = &vfmts[i];
-
         i++;
     }
 
@@ -473,9 +470,11 @@ int main(int argc, char *argv[])
         args.offset *= -1;
 
     if (args.quantize) {
-        //RLE optimise discard palette entry zero, we have 254 usable colors.
-        if (args.rle_optimise && args.quantize == 255)
+        //RLE optimise discard palette entry zero, we have one less usable entry, ensure we don't overshoot the 8-bit id
+        if (args.rle_optimise && args.quantize >= 256) {
             args.quantize -= 1;
+            printf("ass2bdnxml: RLE optimisation enabled, only using %d colors.\n", args.quantize);
+        }
         liqargs.max_quality = MAX(0, MIN(100, liqargs.max_quality));
     } else if (liq_params) {
         printf("Set up libimagequant parameters but not using --quantize.\n");

--- a/common.h
+++ b/common.h
@@ -45,7 +45,7 @@ typedef struct opts_s {
     uint8_t hinting      : 1;
     uint8_t split        : 1;
     uint8_t rle_optimise : 1;
-    uint8_t find_dupes   : 1;
+    uint8_t keep_dupes   : 1;
     uint8_t _pad         : 3;
     const char *fontdir;
 } opts_t;

--- a/render.c
+++ b/render.c
@@ -614,7 +614,6 @@ static int get_frame(ASS_Renderer *renderer, ASS_Track *track, image_t *prev_fra
     ASS_Image *img = ass_render_frame(renderer, track, ms, &changed);
 
     if (changed && img) {
-        frame->out = frame_cnt + 1;
         blend(frame, img);
         //frame differ from the previous?
         if (NULL == prev_frame) {
@@ -628,6 +627,7 @@ static int get_frame(ASS_Renderer *renderer, ASS_Track *track, image_t *prev_fra
             ++frame->out;
             return 1;
         }
+        frame->out = frame_cnt + 1;
 
         if (frame->subx1 == -1 || frame->suby1 == -1)
             return 2;
@@ -692,7 +692,7 @@ eventlist_t *render_subs(char *subfile, frate_t *frate, opts_t *args, liqopts_t 
 
     image_t *frame = image_init(args->frame_w, args->frame_h, args->dvd_mode);
     image_t *prev_frame;
-    prev_frame = args->find_dupes ? image_init(args->frame_w, args->frame_h, args->dvd_mode) : NULL;
+    prev_frame = args->keep_dupes ? NULL : image_init(args->frame_w, args->frame_h, args->dvd_mode);
 
     while (1) {
         if (fres && fres != 2 && count) {


### PR DESCRIPTION
This MR optimizes the generation of palettes with respect to PGS constraints.

In comparison to master:
- Always allocate the transparent palette entry to the last index.
- RLE optimization enabled: up to 255 palette entries are usable, rather than 254.
- General case: up to 256 palette entries are usable, rather than 255.
- If a bitmap uses the entire palette but lacks any transparency, ass2bdnxml lowers the max number of color by one and re-quantize the image.