### PR TITLE
Improve split modes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ The following optional arguments are available:
 | ``--fontdir``      | embedded in the ASS or provided by the OS font manager.|
 +--------------------+--------------------------------------------------------+
 | ``-s``             | Sets the event split across 2 graphics behaviour.      |
-| ``--split``        | 0: Disabled, 1: Normal, 2: Strong, 3: Very aggressive. |
+| ``--split``        | 0: Off, 1: Normal, 2: Strong, 3: Aggressive, 4: Ugly   |
 |                    | Default: ``0`` (Disabled)                              |
 |                    | **Note: DO NOT USE if target is SUPer.**               |
 +--------------------+--------------------------------------------------------+

--- a/ass2bdnxml.c
+++ b/ass2bdnxml.c
@@ -360,14 +360,14 @@ int main(int argc, char *argv[])
                 break;
             case 's':
                 args.split = (uint8_t)strtol(optarg, NULL, 10);
-                if (args.split > 3) {
+                if (args.split > 4) {
                     printf("Invalid split mode.\n");
                     exit(1);
                 }
                 break;
             case 'w':
                 args.render_w = (int)strtol(optarg, NULL, 10);
-                if (args.render_w <= 0 || args.render_w > 4096) {
+                if (args.render_w <= 32 || args.render_w > 4096) {
                     printf("Invalid render width.\n");
                     exit(1);
                 }
@@ -382,7 +382,7 @@ int main(int argc, char *argv[])
             //long args
             case OPT_ARG_FRAME_HEIGHT:
                 args.render_h = (int)strtol(optarg, NULL, 10);
-                if (args.render_h <= 0 || args.render_h > 4096) {
+                if (args.render_h <= 32 || args.render_h > 4096) {
                     printf("Invalid render height.\n");
                     exit(1);
                 }

--- a/common.h
+++ b/common.h
@@ -42,14 +42,15 @@ typedef struct opts_s {
     int storage_h;
     uint16_t quantize;
     uint16_t splitmargin[2];
-    uint8_t dvd_mode     : 1;
-    uint8_t hinting      : 1;
-    uint8_t split        : 1;
-    uint8_t rle_optimise : 1;
-    uint8_t keep_dupes   : 1;
-    uint8_t anamorphic   : 1;
-    uint8_t fullscreen   : 1;
-    uint8_t square_px    : 1;
+    uint16_t dvd_mode     : 1;
+    uint16_t hinting      : 1;
+    uint16_t split        : 4;
+    uint16_t rle_optimise : 1;
+    uint16_t keep_dupes   : 1;
+    uint16_t anamorphic   : 1;
+    uint16_t fullscreen   : 1;
+    uint16_t square_px    : 1;
+    uint16_t _bpad        : 5;
     const char *fontdir;
 } opts_t;
 


### PR DESCRIPTION
- Add overly optimised ugly split mode, similar to the one in avs2bdnxml.
- Ensure bitmaps are always at least 8x8 pixels.
- Adjust loop boundaries to ensure all pixels are processed without overlaps.