### PR TITLE
Add dimming for HDR and subsampling.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,9 +69,10 @@ The following optional arguments are available:
 | ``-p``             | Set custom pixel aspect ratio in rendering.            |
 | ``--par``          | Format: floating point or fraction like ``852:720``.   |
 +--------------------+--------------------------------------------------------+
-|                    | Sets a dimming percentage, floating value, in [0, 100] |
+|                    | Sets a floating value dimming percentage, in [0, 100]. |
 | ``--dim``          | Default: ``0`` (no dimming). Dimming prevents blinding |
-|                    | subtitles with HDR content.                            |
+|                    | subtitles with HDR content. SDR white dimmed by 33%    |
+|                    | will make white subtitles display at roughly 200 nits. |
 +--------------------+--------------------------------------------------------+
 | ``-o``             | Sets the TC offset to shift all of the BDN Timecodes.  |
 | ``--offset``       | Default: ``00:00:00:00`` (offset of zero frame)        |
@@ -155,7 +156,6 @@ Moreover, the last table has debugging parameters. These should not have any pra
 Notes
 -----
 
-- 480p and 576p shall only be used to produce captions for secondary video streams, not primary.
 - Real 60 fps is only supported on the UHD BD format.
-- Captions for 4K UHD BDs are always rendered at 1080p. The players upscale the presentation graphics on playback.
-- For Blu-ray, 59.94 is seemingly only for 720p59.94 content. 1080i59.94 should use 29.97, but there may be some leeway and it does not appear to be enforced.
+- Captions for 4K UHD BDs are always rendered at 1080p. BD players always upscale the presentation graphics on playback, as native 2160p subtitles are strictly forbidden by the Blu-ray format.
+- 59.94 is reserved for 480i59.94 and 720p59.94 content. 1080i is either 25 or 29.97, but there may be some leeway.

--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,10 @@ The following optional arguments are available:
 | ``-p``             | Set custom pixel aspect ratio in rendering.            |
 | ``--par``          | Format: floating point or fraction like ``852:720``.   |
 +--------------------+--------------------------------------------------------+
+|                    | Sets a dimming percentage, floating value, in [0, 100] |
+| ``--dim``          | Default: ``0`` (no dimming). Dimming prevents blinding |
+|                    | subtitles with HDR content.                            |
++--------------------+--------------------------------------------------------+
 | ``-o``             | Sets the TC offset to shift all of the BDN Timecodes.  |
 | ``--offset``       | Default: ``00:00:00:00`` (offset of zero frame)        |
 |                    | Note: TC string must be the standard SMPTE NDF format. |
@@ -93,6 +97,10 @@ The following optional arguments are available:
 | ``-x``             | Sets the ASS storage width, defaults to BDN width.     |
 | ``--width-store``  | Equals unsqueezed width for SD anamorphic.             |
 |                    | Prefer ``-h`` if possible.                             |
++--------------------+--------------------------------------------------------+
+| ``-z``             | Additive flag to increment the minimum event duration. |
+| ``--downsample``   | The time grid is adaptive and not constrained to every |
+|                    | other frame. ``-z -z`` sets a min duration of 3 frames.|
 +--------------------+--------------------------------------------------------+
 
 The naming scheme for ``--width-render`` and ``--width-store`` with respect to the expected values may

--- a/ass2bdnxml.c
+++ b/ass2bdnxml.c
@@ -60,19 +60,23 @@ vfmt_t vfmts[] = {
     {NULL, 0, 0, 0, 0, 0}
 };
 
-#define OPT_ARG_VERSION        975
-
-#define OPT_ARG_SQUAREPIX      993
-#define OPT_ARG_NEGATIVE       994
-#define OPT_ARG_DVD_MODE       995
-#define OPT_ARG_FRAME_HEIGHT   996
-#define OPT_ARG_STORAGE_HEIGHT 997
-#define OPT_ARG_HINTING        998
-#define OPT_ARG_KEEPDUPES      999
-
-#define OPT_LIQ_SPEED         1000
-#define OPT_LIQ_DITHER        1001
-#define OPT_LIQ_MAXQUAL       1002
+enum opts_short_e {
+    //A2B general
+    OPT_ARG_VERSION        = 975,
+    //A2B renderer
+    OPT_ARG_DIM            = 992,
+    OPT_ARG_SQUAREPIX,
+    OPT_ARG_NEGATIVE,
+    OPT_ARG_DVD_MODE,
+    OPT_ARG_FRAME_HEIGHT,
+    OPT_ARG_STORAGE_HEIGHT,
+    OPT_ARG_HINTING,
+    OPT_ARG_KEEPDUPES,
+    //LIQ
+    OPT_LIQ_SPEED          = 1000,
+    OPT_LIQ_DITHER,
+    OPT_LIQ_MAXQUAL
+};
 
 static void die_usage(const char *name)
 {
@@ -260,9 +264,11 @@ int main(int argc, char *argv[])
         {"trackname",    required_argument, 0, 't'},
         {"fullscreen",   no_argument,       0, 'u'},
         {"video-format", required_argument, 0, 'v'},
-        {"squarepx",     no_argument,       0, OPT_ARG_SQUAREPIX},
         {"width-render", required_argument, 0, 'w'},
         {"width-store",  required_argument, 0, 'x'},
+        {"downsample",   no_argument,       0, 'z'},
+        {"dim",          required_argument, 0, OPT_ARG_DIM},
+        {"squarepx",     no_argument,       0, OPT_ARG_SQUAREPIX},
         {"height-render",required_argument, 0, OPT_ARG_FRAME_HEIGHT},
         {"height-store", required_argument, 0, OPT_ARG_STORAGE_HEIGHT},
         {"dvd-mode",     no_argument,       0, OPT_ARG_DVD_MODE},
@@ -289,9 +295,6 @@ int main(int argc, char *argv[])
             case 'c':
                 copy_name = 1;
                 break;
-            case 'd':
-                args.dvd_mode = 1;
-                break;
             case 'h':
                 args.anamorphic = 1;
                 break;
@@ -301,7 +304,21 @@ int main(int argc, char *argv[])
             case 'u':
                 args.fullscreen = 1;
                 break;
-            case OPT_ARG_SQUAREPIX: // 'z'
+            case 'z':
+                ++args.downsampled;
+                break;
+            case OPT_ARG_DIM:
+                args.dimf = (float)strtod(optarg, NULL);
+                if (args.dimf < 0.0 || args.dimf > 100.0) {
+                    printf("Dimming coefficient not a valid percentage.\n");
+                    exit(1);
+                }
+                args.dimf = MAX(0.0f, MIN(1.0f, 1.0f - (args.dimf/100.0f)));
+                break;
+            case OPT_ARG_DVD_MODE:
+                args.dvd_mode = 1;
+                break;
+            case OPT_ARG_SQUAREPIX:
                 args.square_px = 1;
                 break;
             case OPT_ARG_NEGATIVE:
@@ -481,6 +498,11 @@ int main(int argc, char *argv[])
 
     if (vfmt == NULL) {
         printf("Invalid video format.\n");
+        exit(1);
+    }
+
+    if (args.dvd_mode && args.dimf) {
+        printf("Cannot use both DVD mode and dimming for HDR.\n");
         exit(1);
     }
 

--- a/ass2bdnxml.c
+++ b/ass2bdnxml.c
@@ -27,7 +27,7 @@
 
 #include "common.h"
 
-#define A2B_VERSION_STRING "0.8"
+#define A2B_VERSION_STRING "0.7c"
 
 frate_t frates[] = {
     {"23.976",24, 24000, 1001},
@@ -57,6 +57,7 @@ vfmt_t vfmts[] = {
     {"576i",  1024, 720, 768, 720,  576},
     {"480p",  852,  720, 640, 720,  480}, //Secondary videostream only
     {"480i",  852,  720, 640, 720,  480},
+    {"2160p", 3840, 2160, -1, 3840, 2160},//Illegal, provided out of sympathy
     {NULL, 0, 0, 0, 0, 0}
 };
 
@@ -312,6 +313,8 @@ int main(int argc, char *argv[])
                 if (args.dimf < 0.0 || args.dimf > 100.0) {
                     printf("Dimming coefficient not a valid percentage.\n");
                     exit(1);
+                } else {
+                    args.dim_flag = 1;
                 }
                 args.dimf = MAX(0.0f, MIN(1.0f, 1.0f - (args.dimf/100.0f)));
                 break;
@@ -499,6 +502,8 @@ int main(int argc, char *argv[])
     if (vfmt == NULL) {
         printf("Invalid video format.\n");
         exit(1);
+    } else if (vfmt->h == 2160) {
+        printf("WARNING " A2B_LOG_PREFIX "2160p is NOT a valid BDN format. It is only provided for exotic exports like DCPs!\n");
     }
 
     if (args.dvd_mode && args.dimf) {
@@ -527,7 +532,7 @@ int main(int argc, char *argv[])
             args.par = vfmt->w / (double)vfmt->w_scaled;
         }
     } else if (args.anamorphic || args.square_px) {
-        printf("Pixel stretch flag set on non-SD output, aborting.\nUse \"--width-store DISPLAY_W --width-render SQUEEZED_W\" if absolutely needed.\n");
+        printf("Pixel stretch on non-SD output, aborting.\nUse \"--width-store DISPLAY_W --width-render SQUEEZED_W\" if absolutely needed.\n");
         exit(1);
     }
 

--- a/ass2bdnxml.c
+++ b/ass2bdnxml.c
@@ -27,7 +27,7 @@
 
 #include "common.h"
 
-#define A2B_VERSION_STRING "0.7b"
+#define A2B_VERSION_STRING "0.8"
 
 frate_t frates[] = {
     {"23.976",24, 24000, 1001},
@@ -524,7 +524,7 @@ int main(int argc, char *argv[])
             args.storage_w = vfmt->w_frame_anamorphic;
         }
         if (args.square_px) {
-            args.par = vfmt->w_scaled / (double)vfmt->w;
+            args.par = vfmt->w / (double)vfmt->w_scaled;
         }
     } else if (args.anamorphic || args.square_px) {
         printf("Pixel stretch flag set on non-SD output, aborting.\nUse \"--width-store DISPLAY_W --width-render SQUEEZED_W\" if absolutely needed.\n");

--- a/common.h
+++ b/common.h
@@ -52,7 +52,7 @@ typedef struct opts_s {
     uint32_t fullscreen   : 1;
     uint32_t square_px    : 1;
     uint32_t downsampled  : 4;
-    uint32_t _bpad0       : 1; //8
+    uint32_t dim_flag     : 1;
     uint32_t _bpad1       : 16;
     const char *fontdir;
 } opts_t;

--- a/common.h
+++ b/common.h
@@ -33,6 +33,7 @@ typedef struct eventlist_s {
 
 typedef struct opts_s {
     double par;
+    float dimf;
     int64_t offset;
     int frame_w;
     int frame_h;
@@ -42,15 +43,17 @@ typedef struct opts_s {
     int storage_h;
     uint16_t quantize;
     uint16_t splitmargin[2];
-    uint16_t dvd_mode     : 1;
-    uint16_t hinting      : 1;
-    uint16_t split        : 4;
-    uint16_t rle_optimise : 1;
-    uint16_t keep_dupes   : 1;
-    uint16_t anamorphic   : 1;
-    uint16_t fullscreen   : 1;
-    uint16_t square_px    : 1;
-    uint16_t _bpad        : 5;
+    uint32_t dvd_mode     : 1;
+    uint32_t hinting      : 1;
+    uint32_t split        : 4;
+    uint32_t rle_optimise : 1;
+    uint32_t keep_dupes   : 1; //8
+    uint32_t anamorphic   : 1;
+    uint32_t fullscreen   : 1;
+    uint32_t square_px    : 1;
+    uint32_t downsampled  : 4;
+    uint32_t _bpad0       : 1; //8
+    uint32_t _bpad1       : 16;
     const char *fontdir;
 } opts_t;
 

--- a/render.c
+++ b/render.c
@@ -387,7 +387,7 @@ static void blend_single(image_t * frame, ASS_Image *img)
 
 #define DIM_COLOR(c, p) (uint8_t)(round(p*(float)c))
 
-static void blend(image_t *frame, ASS_Image *img, opts_t *args)
+static void blend(image_t *frame, ASS_Image *img, const float dimf, const uint8_t dim_flag)
 {
     int x, y, c;
     uint8_t *buf = frame->buffer;
@@ -416,10 +416,10 @@ static void blend(image_t *frame, ASS_Image *img, opts_t *args)
                 frame->subx2 = MAX(frame->subx2, x);
                 frame->suby2 = MAX(frame->suby2, y);
 
-                if (args->dimf) {
-                    buf[c  ] = DIM_COLOR(buf[c  ], args->dimf);
-                    buf[c+1] = DIM_COLOR(buf[c+1], args->dimf);
-                    buf[c+2] = DIM_COLOR(buf[c+2], args->dimf);
+                if (dim_flag) {
+                    buf[c  ] = DIM_COLOR(buf[c  ], dimf);
+                    buf[c+1] = DIM_COLOR(buf[c+1], dimf);
+                    buf[c+2] = DIM_COLOR(buf[c+2], dimf);
                 }
             }
         }
@@ -639,7 +639,7 @@ static int get_frame(ASS_Renderer *renderer, ASS_Track *track, image_t *prev_fra
     ASS_Image *img = ass_render_frame(renderer, track, ms, &changed);
 
     if (changed && img) {
-        blend(frame, img, args);
+        blend(frame, img, args->dimf, args->dim_flag);
         //frame differ from the previous?
         if (NULL == prev_frame) {
             frame->in = frame_cnt;

--- a/render.c
+++ b/render.c
@@ -385,7 +385,9 @@ static void blend_single(image_t * frame, ASS_Image *img)
     }
 }
 
-static void blend(image_t *frame, ASS_Image *img)
+#define DIM_COLOR(c, p) (uint8_t)(round(p*(float)c))
+
+static void blend(image_t *frame, ASS_Image *img, opts_t *args)
 {
     int x, y, c;
     uint8_t *buf = frame->buffer;
@@ -413,6 +415,12 @@ static void blend(image_t *frame, ASS_Image *img)
 
                 frame->subx2 = MAX(frame->subx2, x);
                 frame->suby2 = MAX(frame->suby2, y);
+
+                if (args->dimf) {
+                    buf[c  ] = DIM_COLOR(buf[c  ], args->dimf);
+                    buf[c+1] = DIM_COLOR(buf[c+1], args->dimf);
+                    buf[c+2] = DIM_COLOR(buf[c+2], args->dimf);
+                }
             }
         }
 
@@ -623,7 +631,7 @@ static uint8_t diff_frames(image_t *current, image_t *prev)
 }
 
 static int get_frame(ASS_Renderer *renderer, ASS_Track *track, image_t *prev_frame,
-                     image_t *frame, uint64_t frame_cnt, frate_t *frate)
+                     image_t *frame, uint64_t frame_cnt, frate_t *frate, opts_t *args)
 {
     int changed;
 
@@ -631,7 +639,7 @@ static int get_frame(ASS_Renderer *renderer, ASS_Track *track, image_t *prev_fra
     ASS_Image *img = ass_render_frame(renderer, track, ms, &changed);
 
     if (changed && img) {
-        blend(frame, img);
+        blend(frame, img, args);
         //frame differ from the previous?
         if (NULL == prev_frame) {
             frame->in = frame_cnt;
@@ -725,7 +733,7 @@ eventlist_t *render_subs(char *subfile, frate_t *frate, opts_t *args, liqopts_t 
             eventlist_set(evlist, frame, count - 1);
         }
 
-        fres = get_frame(ass_renderer, track, prev_frame, frame, frame_cnt, frate);
+        fres = get_frame(ass_renderer, track, prev_frame, frame, frame_cnt, frate, args);
 
         switch (fres) {
             case 3:
@@ -760,6 +768,10 @@ eventlist_t *render_subs(char *subfile, frate_t *frate, opts_t *args, liqopts_t 
                     liq_image_destroy(img);
                 }
                 count++;
+                if (args->downsampled) {
+                    frame_cnt += args->downsampled;
+                    frame->out += args->downsampled;
+                }
             }
             /* fall through */
             case 2:


### PR DESCRIPTION
- `--downsample` (`-z`) - Extend by one frame the minimum duration of events. `-z` is additive and can be specified more than once _[to increase the minimum event duration]_. This is handy for 1080p HFR (60 FPS) with effects. The sampling grid is adaptive and not affected by the minimum duration: the IN and OUT times of normal subtitles will be gracefully respected!
- `--dim P` - Dim the events by percentage P, a floating point percentage in [0, 100]. Typical values for HDR10 content are within [25, 75] and are selected according to the average number of nits of the movie. Higher dimming should be used for content with low average nits.

A UHD BD player quadruples the 8-bit YCrCb values of the presentation graphics on playback. A pure white overlay would render at 10,000 nits, while the movie could show an average of 150 nits.